### PR TITLE
Fix date format to use 24 hours clock instead of 12.

### DIFF
--- a/queuehandler.go
+++ b/queuehandler.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	nextVideoOrigin  = "http://cmdb.ft.com/systems/next-video-editor"
-	dateFormat       = "2006-01-02T03:04:05.000Z0700"
+	dateFormat       = "2006-01-02T15:04:05.000Z0700"
 	generatedMsgType = "cms-content-published"
 )
 


### PR DESCRIPTION
Merging this fix into the kafka topic check one to release them together.
Supersedes https://github.com/Financial-Times/upp-next-video-content-collection-mapper/pull/2