### PR TITLE
Mark as non-resilient, reduce severity

### DIFF
--- a/healthcheck.go
+++ b/healthcheck.go
@@ -47,7 +47,7 @@ func (h *HealthCheck) readQueueCheck() fthealth.Check {
 	return fthealth.Check{
 		ID:               "read-message-queue-proxy-reachable",
 		Name:             "Read Message Queue Proxy Reachable",
-		Severity:         1,
+		Severity:         2,
 		BusinessImpact:   "Related content from published Next videos will not be processed, clients will not see them within content.",
 		TechnicalSummary: "Read message queue proxy is not reachable/healthy",
 		PanicGuide:       h.panicGuide,
@@ -59,7 +59,7 @@ func (h *HealthCheck) writeQueueCheck() fthealth.Check {
 	return fthealth.Check{
 		ID:               "write-message-queue-proxy-reachable",
 		Name:             "Write Message Queue Proxy Reachable",
-		Severity:         1,
+		Severity:         2,
 		BusinessImpact:   "Related content from published Next videos will not be processed, clients will not see them within content.",
 		TechnicalSummary: "Write message queue proxy is not reachable/healthy",
 		PanicGuide:       h.panicGuide,

--- a/helm/upp-next-video-content-collection-mapper/templates/service.yaml
+++ b/helm/upp-next-video-content-collection-mapper/templates/service.yaml
@@ -7,7 +7,8 @@ metadata:
     chartVersion: "{{ .Chart.Version | trunc 63 }}"
     app: {{.Values.service.name}}
     visualize: "true" 
-    hasHealthcheck: "{{ .Values.service.hasHealthcheck }}" 
+    hasHealthcheck: "{{ .Values.service.hasHealthcheck }}"
+    isResilient: "{{ .Values.service.isResilient }}"
 spec:
   ports: 
     - port: 8080 

--- a/helm/upp-next-video-content-collection-mapper/values.yaml
+++ b/helm/upp-next-video-content-collection-mapper/values.yaml
@@ -4,6 +4,7 @@
 service:
   name: "" # The name of the service, should be defined in the specific app-configs folder.
   hasHealthcheck: "true"
+  isResilient: "false"
 replicaCount: 2
 image:
   repository: coco/upp-next-video-content-collection-mapper


### PR DESCRIPTION
- mappers aren't resilient: both pods read from kafka using the same consumer group - this means only one of them is actually receiving the messages; if the pod which isn't receiving the messages stops, that's not problem, but if the pod who is actually receiving the messages stops working, then the other pod will not pick up messages either
- by marking it as non-resilient, the upp-aggregate-healthcheck (any versions which include this [PR](https://github.com/Financial-Times/upp-aggregate-healthcheck/pull/22)) will report the highest severity of any failed pods as the severity for the service 
- reduced the severity from 1 to 2 so any failures in this service will not turn dashing red