### PR TITLE
Delete payload id -> uuid

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	videoUUIDField     = "id"
+	videoUUIDField     = "uuid"
+	videoIDField       = "id"
 	relatedField       = "related"
 	deletedField       = "deleted"
 	relatedItemIDField = "uuid"
@@ -28,9 +29,19 @@ type relatedContentMapper struct {
 }
 
 func (m *relatedContentMapper) mapRelatedContent() ([]byte, string, error) {
-	videoUUID, err := getRequiredStringField(videoUUIDField, m.unmarshalled)
-	if err != nil {
-		return nil, "", err
+	var videoUUID string
+	var err error
+
+	if m.isDeleteEvent() {
+		videoUUID, err = getRequiredStringField(videoUUIDField, m.unmarshalled)
+		if err != nil {
+			return nil, "", err
+		}
+	} else {
+		videoUUID, err = getRequiredStringField(videoIDField, m.unmarshalled)
+		if err != nil {
+			return nil, "", err
+		}
 	}
 
 	contentCollectionUUID, err := generateContentCollectionUUID(videoUUID)

--- a/mapper.go
+++ b/mapper.go
@@ -29,19 +29,17 @@ type relatedContentMapper struct {
 }
 
 func (m *relatedContentMapper) mapRelatedContent() ([]byte, string, error) {
-	var videoUUID string
-	var err error
+	var uuidField string
 
 	if m.isDeleteEvent() {
-		videoUUID, err = getRequiredStringField(videoUUIDField, m.unmarshalled)
-		if err != nil {
-			return nil, "", err
-		}
+		uuidField = videoUUIDField
 	} else {
-		videoUUID, err = getRequiredStringField(videoIDField, m.unmarshalled)
-		if err != nil {
-			return nil, "", err
-		}
+		uuidField = videoIDField
+	}
+
+	videoUUID, err := getRequiredStringField(uuidField, m.unmarshalled)
+	if err != nil {
+		return nil, "", err
 	}
 
 	contentCollectionUUID, err := generateContentCollectionUUID(videoUUID)

--- a/test-resources/next-video-delete-input.json
+++ b/test-resources/next-video-delete-input.json
@@ -1,1 +1,7 @@
-{"deleted": true,"lastModified": "2017-04-04T14:42:58.920Z","publishReference": "tid_bycjmmcj4r","type": "video","id": "e2290d14-7e80-4db8-a715-949da4de9a07"}
+{
+    "deleted": true,
+    "lastModified": "2017-04-04T14:42:58.920Z",
+    "publishReference": "tid_bycjmmcj4r",
+    "type": "video",
+    "uuid": "e2290d14-7e80-4db8-a715-949da4de9a07"
+}


### PR DESCRIPTION
# Description

## What

The mapper now expects that the payload contains an `uuid` attribute instead of an `id` attribute.  

## Why

In order for the `cm-content-deleter` to be able to use `upp-content-validation-kit` it must receive `uuid` in the payload, therefore we modified the `cms-notifier` to send it in the payload, hence, the mapper needs to change as well so that it recognizes the payload as valid.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
