### PR TITLE
Adding deleted to a delete messages payload

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -59,6 +59,9 @@ func (m *relatedContentMapper) mapRelatedContent() ([]byte, string, error) {
 		if len(relatedItems) > 0 {
 			cc = m.newContentCollection(contentCollectionUUID, relatedItems)
 		}
+	} else {
+		cc.Deleted = true
+		cc.UUID = videoUUID
 	}
 
 	mc := m.newMappedContent(contentCollectionUUID, cc)

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -70,13 +70,13 @@ func TestMapNextVideoRelatedContentHappyFlows(t *testing.T) {
 	}{
 		{
 			"next-video-input.json",
-			newStringMappedContent(t, "c4cde316-128c-11e7-80f4-13e067d5072c", "", ""),
+			newStringMappedContent(t, "c4cde316-128c-11e7-80f4-13e067d5072c", "", "", false),
 			testVideoUUID,
 			false,
 		},
 		{
 			"next-video-delete-input.json",
-			newStringMappedContent(t, "", "", ""),
+			newStringMappedContent(t, "", "", "", true),
 			testVideoUUID,
 			false,
 		},
@@ -238,7 +238,7 @@ func newRelatedItem(id interface{}) map[string]interface{} {
 	return obj
 }
 
-func newStringMappedContent(t *testing.T, itemUUID string, tid string, msgDate string) string {
+func newStringMappedContent(t *testing.T, itemUUID string, tid string, msgDate string, deletePayload bool) string {
 	var cc ContentCollection
 	if itemUUID != "" {
 		items := []Item{{itemUUID}}
@@ -249,6 +249,10 @@ func newStringMappedContent(t *testing.T, itemUUID string, tid string, msgDate s
 			LastModified:     msgDate,
 			CollectionType:   collectionType,
 		}
+	}
+	if deletePayload {
+		cc.Deleted = true
+		cc.UUID = testVideoUUID
 	}
 
 	mc := MappedContent{

--- a/model.go
+++ b/model.go
@@ -7,6 +7,7 @@ type ContentCollection struct {
 	PublishReference string `json:"publishReference,omitempty"`
 	LastModified     string `json:"lastModified,omitempty"`
 	CollectionType   string `json:"type,omitempty"`
+	Deleted          bool   `json:"deleted,omitempty"`
 }
 
 // Item within content collection

--- a/queuehandler_test.go
+++ b/queuehandler_test.go
@@ -32,7 +32,7 @@ func TestQueueConsume(t *testing.T) {
 			"application/json",
 			"1234",
 			true,
-			newStringMappedContent(t, "c4cde316-128c-11e7-80f4-13e067d5072c", "1234", lastModified),
+			newStringMappedContent(t, "c4cde316-128c-11e7-80f4-13e067d5072c", "1234", lastModified, false),
 		},
 		{
 			"next-video-input.json",
@@ -72,7 +72,7 @@ func TestQueueConsume(t *testing.T) {
 			"application/json",
 			"1234",
 			true,
-			newStringMappedContent(t, "", "1234", lastModified),
+			newStringMappedContent(t, "", "1234", lastModified, false),
 		},
 		{
 			"next-video-empty-related-input.json",

--- a/servicehandler_test.go
+++ b/servicehandler_test.go
@@ -28,7 +28,7 @@ func TestMapRequest(t *testing.T) {
 	}{
 		{
 			"next-video-input.json",
-			newStringMappedContent(t, "c4cde316-128c-11e7-80f4-13e067d5072c", "", ""),
+			newStringMappedContent(t, "c4cde316-128c-11e7-80f4-13e067d5072c", "", "", false),
 			http.StatusOK,
 		},
 		{


### PR DESCRIPTION
# Description

## What

Adding a deleted and uuid fields to the payloads of unpublish messages. publishReference does not seem to be needed. You can see the expected format in [post-publication-combiner's model here](https://github.com/Financial-Times/post-publication-combiner/blob/master/processor/model.go).

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3513

## Anything, in particular, you'd like to highlight to reviewers

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
